### PR TITLE
Add all standard IRC-legal nick characters for ? remark lookup. Could…

### DIFF
--- a/src/com/helen/commands/Command.java
+++ b/src/com/helen/commands/Command.java
@@ -350,7 +350,7 @@ public class Command {
         }
     }
 
-    @IRCCommand(command = {"meh"}, reg = true, matcherGroup = 1, securityLevel = 1, regex = "\\?([a-zA-Z0-9]+).*", startOfLine = true)
+    @IRCCommand(command = {"meh"}, reg = true, matcherGroup = 1, securityLevel = 1, regex = "\\?([a-zA-Z0-9_\\-\\|\\[\\]\\{\\}`\\\\]+).*", startOfLine = true)
     public void getMemo(CommandData data) {
         if (Configs.getProperty("remchannels").stream().anyMatch(config -> config.getValue().equalsIgnoreCase(data.getChannel()))) {
             helen.sendOutgoingMessage(data.getResponseTarget(), data.getSender() + ": " + Memo.getMemo(data.getRegexTarget(), data.getChannel()));


### PR DESCRIPTION
… also just use [\S]+ instead for any non-whitespace, (I'd use that over this except that I'm concerned really unusual characters might expose other issues.) Not tested.

Additional chars are underscore, hyphen, pipe, square and curly braces, backtick, and backslash.